### PR TITLE
og tags for socials

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
 <link rel="canonical" href="https://s9a.github.io/cab/">
 <link rel="icon" href="favicon.svg">
 
+<link rel href="https://github.com/s9a/cab/issues/14">
+<meta property=og:image content="https://user-images.githubusercontent.com/949985/93726357-9eb26380-fb83-11ea-9030-d297c32eacc1.png">
+<meta property=og:image:alt content="#cab">
+
 <body class="ska-body">
 
 <header class="ska-block ska-exhale">


### PR DESCRIPTION
uses `#cab` png from #14